### PR TITLE
Support hapi auth "modes"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,11 +139,15 @@ async function handleKeycloakValidation (tkn, h) {
  * @throws {Boom.unauthorized} If header is missing or has an invalid format
  */
 async function validate (field, h = (data) => data) {
+  if (!field) {
+    throw raiseUnauthorized(errorMessages.missing)
+  }
+
   const tkn = token.create(field)
   const reply = fakeToolkit(h)
 
   if (!tkn) {
-    throw raiseUnauthorized(errorMessages.missing)
+    throw raiseUnauthorized(errorMessages.invalid)
   }
 
   const cached = await cache.get(store, tkn)

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,11 +117,15 @@ function verify (opts) {
  * @returns {Boom.unauthorized} The created `Boom` error
  */
 function raiseUnauthorized (error, reason, scheme = 'Bearer') {
-  return boom.unauthorized(null, scheme, {
-    strategy: 'keycloak-jwt',
-    ...(error ? { error } : {}),
-    ...(reason && error !== reason ? { reason } : {})
-  })
+  return boom.unauthorized(
+    error !== errorMessages.missing ? error : null,
+    scheme,
+    {
+      strategy: 'keycloak-jwt',
+      ...(error === errorMessages.missing ? { error } : {}),
+      ...(reason && error !== reason ? { reason } : {})
+    }
+  )
 }
 
 /**
@@ -132,7 +136,7 @@ function raiseUnauthorized (error, reason, scheme = 'Bearer') {
  */
 const errorMessages = {
   invalid: 'Invalid credentials',
-  missing: 'Missing or invalid authorization header',
+  missing: 'Missing authorization header',
   rpt: 'Retrieving the RPT failed',
   apiKey: 'Retrieving the token with the api key failed'
 }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -184,6 +184,32 @@ function registerRoutes (server) {
           }
         }
       }
+    },
+    {
+      method: 'GET',
+      path: '/mode-optional',
+      options: {
+        auth: { strategy: 'keycloak-jwt', mode: 'optional' },
+        handler (req) {
+          return {
+            headers: req.headers,
+            query: req.query
+          }
+        }
+      }
+    },
+    {
+      method: 'GET',
+      path: '/mode-try',
+      options: {
+        auth: { strategy: 'keycloak-jwt', mode: 'try' },
+        handler (req) {
+          return {
+            headers: req.headers,
+            query: req.query
+          }
+        }
+      }
     }
   ])
 }

--- a/test/index.entitlement.spec.js
+++ b/test/index.entitlement.spec.js
@@ -84,7 +84,7 @@ test('authentication does fail – invalid token', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials", reason="Retrieving the RPT failed"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", reason="Retrieving the RPT failed", error="Invalid credentials"')
 })
 
 test('authentication does fail – invalid header', async (t) => {
@@ -95,5 +95,5 @@ test('authentication does fail – invalid header', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Missing or invalid authorization header"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })

--- a/test/index.hapi-modes.spec.js
+++ b/test/index.hapi-modes.spec.js
@@ -11,10 +11,9 @@ test.afterEach.always('reset instances and prototypes', () => {
 
 test('server method – authentication supports mode: "optional" - will succeed without auth', async (t) => {
   const server = await helpers.getServer(cfg)
-
   const res = await server.inject({
     method: 'GET',
-    url: '/mode-optional',
+    url: '/mode-optional'
   })
 
   t.truthy(res)
@@ -22,31 +21,18 @@ test('server method – authentication supports mode: "optional" - will succeed 
 })
 
 test('server method – authentication supports mode: "optional" - will fail with invalid auth', async (t) => {
+  const mockReq = helpers.mockRequest(fixtures.common.token, '/mode-optional')
   const server = await helpers.getServer(cfg)
-
-  const res = await server.inject({
-    method: 'GET',
-    url: '/mode-optional',
-    headers: {
-      authorization: `bearer invalid-token`
-    }
-  })
+  const res = await server.inject(mockReq)
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(err.output.headers['WWW-Authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })
 
 test('server method – authentication supports mode: "try" - will succeed with invalid auth', async (t) => {
+  const mockReq = helpers.mockRequest(fixtures.common.token, '/mode-try')
   const server = await helpers.getServer(cfg)
-
-  const res = await server.inject({
-    method: 'GET',
-    url: '/mode-try',
-    headers: {
-      authorization: `bearer ${fixtures.composeJwt('expired')}`
-    }
-  })
+  const res = await server.inject(mockReq)
 
   t.truthy(res)
   t.is(res.statusCode, 200)

--- a/test/index.hapi-modes.spec.js
+++ b/test/index.hapi-modes.spec.js
@@ -1,0 +1,53 @@
+const nock = require('nock')
+const test = require('ava')
+const helpers = require('./_helpers')
+const fixtures = require('./fixtures')
+
+const cfg = helpers.getOptions({ secret: fixtures.common.secret })
+
+test.afterEach.always('reset instances and prototypes', () => {
+  nock.cleanAll()
+})
+
+test('server method – authentication supports mode: "optional" - will succeed without auth', async (t) => {
+  const server = await helpers.getServer(cfg)
+
+  const res = await server.inject({
+    method: 'GET',
+    url: '/mode-optional',
+  })
+
+  t.truthy(res)
+  t.is(res.statusCode, 200)
+})
+
+test('server method – authentication supports mode: "optional" - will fail with invalid auth', async (t) => {
+  const server = await helpers.getServer(cfg)
+
+  const res = await server.inject({
+    method: 'GET',
+    url: '/mode-optional',
+    headers: {
+      authorization: `bearer invalid-token`
+    }
+  })
+
+  t.truthy(res)
+  t.is(res.statusCode, 401)
+  t.is(err.output.headers['WWW-Authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
+})
+
+test('server method – authentication supports mode: "try" - will succeed with invalid auth', async (t) => {
+  const server = await helpers.getServer(cfg)
+
+  const res = await server.inject({
+    method: 'GET',
+    url: '/mode-try',
+    headers: {
+      authorization: `bearer ${fixtures.composeJwt('expired')}`
+    }
+  })
+
+  t.truthy(res)
+  t.is(res.statusCode, 200)
+})

--- a/test/index.introspect.spec.js
+++ b/test/index.introspect.spec.js
@@ -77,5 +77,5 @@ test('authentication does fail – invalid header', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Missing or invalid authorization header"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })

--- a/test/index.server.spec.js
+++ b/test/index.server.spec.js
@@ -52,7 +52,7 @@ test('server method – authentication does fail – invalid header', async (t) 
   t.truthy(err)
   t.truthy(err.isBoom)
   t.is(err.output.statusCode, 401)
-  t.is(err.output.headers['WWW-Authenticate'], 'Bearer strategy="keycloak-jwt", error="Missing or invalid authorization header"')
+  t.is(err.output.headers['WWW-Authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })
 
 test('server method – authentication does fail – error', async (t) => {

--- a/test/index.verify.buffer.spec.js
+++ b/test/index.verify.buffer.spec.js
@@ -49,7 +49,7 @@ test('authentication does fail – expired token', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials", reason="invalid token (expired)"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", reason="invalid token (expired)", error="Invalid credentials"')
 })
 
 test('authentication does fail – invalid header', async (t) => {
@@ -59,5 +59,5 @@ test('authentication does fail – invalid header', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Missing or invalid authorization header"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })

--- a/test/index.verify.jwk.spec.js
+++ b/test/index.verify.jwk.spec.js
@@ -53,7 +53,7 @@ test('authentication does fail – expired token', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials", reason="invalid token (expired)"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", reason="invalid token (expired)", error="Invalid credentials"')
 })
 
 test('authentication does fail – invalid header', async (t) => {
@@ -63,5 +63,5 @@ test('authentication does fail – invalid header', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Missing or invalid authorization header"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })

--- a/test/index.verify.pem.spec.js
+++ b/test/index.verify.pem.spec.js
@@ -49,7 +49,7 @@ test('authentication does fail – expired token', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials", reason="invalid token (expired)"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", reason="invalid token (expired)", error="Invalid credentials"')
 })
 
 test('authentication does fail – invalid header', async (t) => {
@@ -59,5 +59,5 @@ test('authentication does fail – invalid header', async (t) => {
 
   t.truthy(res)
   t.is(res.statusCode, 401)
-  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Missing or invalid authorization header"')
+  t.is(res.headers['www-authenticate'], 'Bearer strategy="keycloak-jwt", error="Invalid credentials"')
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -27,21 +27,11 @@ test('get boom error with custom scheme', (t) => {
   }))
 })
 
-test('get boom error with default message', (t) => {
-  const result = utils.raiseUnauthorized('foobar')
-  t.truthy(result)
-  t.deepEqual(result, boom.unauthorized(null, 'Bearer', {
-    strategy: 'keycloak-jwt',
-    error: 'foobar'
-  }))
-})
-
 test('get boom error with error message', (t) => {
   const result = utils.raiseUnauthorized('foobar')
   t.truthy(result)
-  t.deepEqual(result, boom.unauthorized(null, 'Bearer', {
-    strategy: 'keycloak-jwt',
-    error: 'foobar'
+  t.deepEqual(result, boom.unauthorized('foobar', 'Bearer', {
+    strategy: 'keycloak-jwt'
   }))
 })
 


### PR DESCRIPTION
Added tests to check hapi's `mode: 'optional'` and `mode: 'try'`.