### PR TITLE
Enable Multi-Tenant Support by making Scheme Name flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Optional. Default: `undefined`.
   - `request {Object}` – The detailed request options for [`got`][got].<br/>
   Optional. Default: `{}`
 
-#### `await server.kjwt.validate(field {string})`
+#### `await server[decoratorName = 'kjwt'].validate(field {string})`
 - `field {string}` — The `Bearer` field, including the scheme (`bearer`) itself.<br/>
 Example: `bearer 12345.abcde.67890`.<br/>
 Required.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ server.route([
 > Please mind that the accurate strategy is 4-5x faster than the fine-grained one.<br/>
 > **Hint:** If you define neither `secret` nor `public` nor `entitlement`, the plugin retrieves the public key itself from `{realmUrl}/protocol/openid-connect/certs`.
 
+- `schemeName {string}` — The name used for the authentication scheme of the hapi server. Optional. Default: `keycloak-jwt`.
+
+- `decoratorName {string}` — The name used for the server decorator to validate the token, see below. Optional. Default: `kjwt`.
+
 - `realmUrl {string}` – The absolute uri of the Keycloak realm.<br/>
 Required. Example: `https://localhost:8080/auth/realms/testme`<br/>
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ server.route([
 
 - `schemeName {string}` — The name used for the authentication scheme of the hapi server. Optional. Default: `keycloak-jwt`.
 
-- `decoratorName {string}` — The name used for the server decorator to validate the token, see below. Optional. Default: `kjwt`.
+- `decoratorName {string}` — The name used for the server decorator to validate the token, [see below](#await-serverdecoratorname--kjwtvalidatefield-string). Optional. Default: `kjwt`.
 
 - `realmUrl {string}` – The absolute uri of the Keycloak realm.<br/>
 Required. Example: `https://localhost:8080/auth/realms/testme`<br/>

--- a/src/index.js
+++ b/src/index.js
@@ -191,8 +191,9 @@ function register (server, opts) {
   store = cache.create(server, options.cache)
 
   apiKey.init(server, options)
-  server.auth.scheme('keycloak-jwt', strategy)
-  server.decorate('server', 'kjwt', { validate })
+
+  server.auth.scheme(options.schemeName, strategy)
+  server.decorate('server', options.decoratorName, { validate })
 }
 
-module.exports = { register, pkg }
+module.exports = { register, pkg, multiple: true }

--- a/src/index.js
+++ b/src/index.js
@@ -192,6 +192,14 @@ function register (server, opts) {
 
   apiKey.init(server, options)
 
+  if (options.schemeName in server.auth._schemes) {
+    throw Error(`Authentication strategy named ${options.schemeName} already exists.`)
+  }
+
+  if (options.decoratorName in server._core._decorations['server']) {
+    throw Error(`Server decorator named ${options.decoratorName} already exists.`)
+  }
+
   server.auth.scheme(options.schemeName, strategy)
   server.decorate('server', options.decoratorName, { validate })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,10 @@ const jwkToPem = require('jwk-to-pem')
  * The plugin options scheme
  */
 const scheme = joi.object({
+  schemeName: joi.string().empty(['']).default('keycloak-jwt')
+    .description('The name for the auth scheme for the hapi server'),
+  decoratorName: joi.string().empty(['']).default('kjwt')
+    .description('The name for the server decorator to validate tokens'),
   realmUrl: joi.string().uri().required()
     .description('The absolute uri of the Keycloak realm')
     .example('https://localhost:8080/auth/realms/testme'),

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -10,6 +10,8 @@ const fixtures = require('./fixtures')
  * The default plugin configuration
  */
 const defaults = {
+  schemeName: 'keycloak-jwt',
+  decoratorName: 'kjwt',
   realmUrl: fixtures.common.realmUrl,
   clientId: fixtures.common.clientId
 }
@@ -221,17 +223,22 @@ function registerRoutes (server) {
  * Register the plugin with passed options
  *
  * @param {Hapi.Server} server The server to be decorated
- * @param {Object} options The plugin related options
- * @param {Function} done The success callback handler
+ * @param {Object} opts The plugin related options
+ * @param {boolean} skipRoutes Whether to skip route definition
  */
-async function registerPlugin (server, options = defaults) {
+async function registerPlugin (server, opts = {}, skipRoutes = false) {
+  const options = { ...defaults, ...opts }
+
   await server.register({
     plugin: authKeycloak,
     options
   })
 
-  server.auth.strategy('keycloak-jwt', 'keycloak-jwt')
-  registerRoutes(server)
+  server.auth.strategy(options.schemeName, options.schemeName)
+
+  if (!skipRoutes) {
+    registerRoutes(server)
+  }
 
   return server
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,7 +13,7 @@ test('throw error if plugin gets registered twice with different scheme names', 
     schemeName: 'foobar'
   }, true))
 
-  t.is(Object.keys(server.auth._schemes).length, 2)
+  t.is(Object.keys(server.auth._schemes).length, 1)
 })
 
 test('throw error if plugin gets registered twice with different decorator names', async (t) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,5 +3,35 @@ const helpers = require('./_helpers')
 
 test('throw error if plugin gets registered twice', async (t) => {
   const server = await helpers.getServer(undefined)
-  await t.throwsAsync(helpers.registerPlugin(server))
+  await t.throwsAsync(helpers.registerPlugin(server, undefined, true))
+  t.is(Object.keys(server.auth._schemes).length, 1)
+})
+
+test('throw error if plugin gets registered twice with different scheme names', async (t) => {
+  const server = await helpers.getServer(undefined)
+  await t.throwsAsync(helpers.registerPlugin(server, {
+    schemeName: 'foobar'
+  }, true))
+
+  t.is(Object.keys(server.auth._schemes).length, 2)
+})
+
+test('throw error if plugin gets registered twice with different decorator names', async (t) => {
+  const server = await helpers.getServer(undefined)
+  await t.throwsAsync(helpers.registerPlugin(server, {
+    decoratorName: 'fb'
+  }, true))
+
+  t.is(Object.keys(server.auth._schemes).length, 1)
+})
+
+test('throw no error if plugin gets registered twice with different names', async (t) => {
+  const server = await helpers.getServer(undefined)
+
+  await t.notThrowsAsync(helpers.registerPlugin(server, {
+    schemeName: 'foobar',
+    decoratorName: 'fb'
+  }, true))
+
+  t.is(Object.keys(server.auth._schemes).length, 2)
 })

--- a/test/utils.validate.spec.js
+++ b/test/utils.validate.spec.js
@@ -50,6 +50,48 @@ test('throw error if options are empty', (t) => {
   t.throws(() => utils.verify({}))
 })
 
+test('throw error if options are invalid – schemeName', (t) => {
+  const invalids = [
+    null,
+    NaN,
+    42,
+    true,
+    false,
+    [],
+    new RegExp(),
+    {}
+  ]
+
+  t.plan(invalids.length)
+
+  invalids.forEach((invalid) => {
+    t.throws(() => utils.verify(helpers.getOptions({
+      schemeName: invalid
+    })))
+  })
+})
+
+test('throw error if options are invalid – decoratorName', (t) => {
+  const invalids = [
+    null,
+    NaN,
+    42,
+    true,
+    false,
+    [],
+    new RegExp(),
+    {}
+  ]
+
+  t.plan(invalids.length)
+
+  invalids.forEach((invalid) => {
+    t.throws(() => utils.verify(helpers.getOptions({
+      decoratorName: invalid
+    })))
+  })
+})
+
 test('throw error if options are invalid – realmUrl', (t) => {
   const invalids = [
     null,
@@ -436,6 +478,40 @@ test('throw error if options are invalid – publicKey/secret/entitlement confli
     secret: fixtures.common.secret,
     entitlement: true
   })))
+})
+
+test('throw no error if options are valid – schemeName', (t) => {
+  const customValids = [
+    ...valids,
+    { schemeName: '' },
+    { schemeName: 'foobar' },
+    { schemeName: undefined }
+  ]
+
+  t.plan(customValids.length)
+
+  customValids.forEach((valid) => {
+    t.notThrows(
+      () => utils.verify(helpers.getOptions(valid))
+    )
+  })
+})
+
+test('throw no error if options are valid – decoratorName', (t) => {
+  const customValids = [
+    ...valids,
+    { decoratorName: '' },
+    { decoratorName: 'foobar' },
+    { decoratorName: undefined }
+  ]
+
+  t.plan(customValids.length)
+
+  customValids.forEach((valid) => {
+    t.notThrows(
+      () => utils.verify(helpers.getOptions(valid))
+    )
+  })
 })
 
 test('throw no error if options are valid – secret', (t) => {

--- a/test/utils.validate.spec.js
+++ b/test/utils.validate.spec.js
@@ -573,3 +573,13 @@ test('throw no error if options are valid – publicKey/JWK', (t) => {
     )
   })
 })
+
+test('sets default correctly – schemeName', (t) => {
+  const opts = utils.verify(helpers.getOptions({ schemeName: undefined }))
+  t.is(opts.schemeName, 'keycloak-jwt')
+})
+
+test('sets default correctly – decoratorName', (t) => {
+  const opts = utils.verify(helpers.getOptions({ decoratorName: undefined }))
+  t.is(opts.decoratorName, 'kjwt')
+})


### PR DESCRIPTION
This PR is related to #19 and builds on top of #20 — thanks a million to @youett for your feature request and the initial work 🙏 🤗 

Due to inactivity in #20 I continued in a separate branch.
It enables multi-tenant support by supporting the multiple registration of the plugin and allowing to define the names of scheme/decorator. It's fully backwards compatible due to proper defaults.